### PR TITLE
Controlador XML a JSON

### DIFF
--- a/app/Http/Controllers/XmlController.php
+++ b/app/Http/Controllers/XmlController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class XmlController extends Controller
+{
+    public function mostrar()
+    {
+        $xmlPath = storage_path('xml/libros.xml');
+
+        if (!file_exists($xmlPath)) {
+            return response()->json(['error' => 'Archivo XML no encontrado.'], 404);
+        }
+
+        $xml = simplexml_load_file($xmlPath);
+
+        $libros = [];
+
+        foreach ($xml->libro as $libro) {
+            $libros[] = [
+                'titulo' => (string) $libro->titulo,
+                'autor' => (string) $libro->autor,
+                'anio' => (int) $libro->anio,
+            ];
+        }
+
+        // Convertimos a JSON para cumplir con el requisito
+        $jsonLibros = json_encode($libros);
+
+        // Enviamos el JSON decodificado a la vista
+        return view('preferencias', ['libros' => json_decode($jsonLibros)]);
+    }
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Backend\Roles\PermisoController;
 use App\Http\Controllers\Backend\Perfil\PerfilController;
 use App\Http\Controllers\Backend\Configuracion\ConfiguracionController;
 use App\Http\Controllers\Backend\Registro\RegistroController;
-
+use App\Http\Controllers\XmlController;
 
 
 use App\Http\Controllers\Backend\Dashboard\DashboardController;
@@ -57,4 +57,5 @@ Route::get('sin-permisos', [ControlController::class,'indexSinPermiso'])->name('
 
 Route::get('/admin/dashboard', [DashboardController::class,'vistaDashboard'])->name('admin.dashboard.index');
 
+Route::get('/xml', [XmlController::class, 'mostrar']);
 

--- a/storage/xml/libros.xml
+++ b/storage/xml/libros.xml
@@ -1,0 +1,54 @@
+<libros>
+  <libro>
+    <titulo>El Quijote</titulo>
+    <autor>Miguel de Cervantes</autor>
+    <anio>1605</anio>
+  </libro>
+  <libro>
+    <titulo>Cien Años de Soledad</titulo>
+    <autor>Gabriel García Márquez</autor>
+    <anio>1967</anio>
+  </libro>
+  <libro>
+    <titulo>La Sombra del Viento</titulo>
+    <autor>Carlos Ruiz Zafón</autor>
+    <anio>2001</anio>
+  </libro>
+  <libro>
+    <titulo>1984</titulo>
+    <autor>George Orwell</autor>
+    <anio>1949</anio>
+  </libro>
+  <libro>
+    <titulo>Crónica de una Muerte Anunciada</titulo>
+    <autor>Gabriel García Márquez</autor>
+    <ani<libros>
+  <libro>
+    <titulo>El Quijote</titulo>
+    <autor>Miguel de Cervantes</autor>
+    <anio>1605</anio>
+  </libro>
+  <libro>
+    <titulo>Cien Años de Soledad</titulo>
+    <autor>Gabriel García Márquez</autor>
+    <anio>1967</anio>
+  </libro>
+  <libro>
+    <titulo>La Sombra del Viento</titulo>
+    <autor>Carlos Ruiz Zafón</autor>
+    <anio>2001</anio>
+  </libro>
+  <libro>
+    <titulo>1984</titulo>
+    <autor>George Orwell</autor>
+    <anio>1949</anio>
+  </libro>
+  <libro>
+    <titulo>Crónica de una Muerte Anunciada</titulo>
+    <autor>Gabriel García Márquez</autor>
+    <anio>1981</anio>
+  </libro>
+</libros>
+o>1981</anio>
+  </libro>
+</libros>

--- a/storage/xml/libros.xml
+++ b/storage/xml/libros.xml
@@ -22,33 +22,36 @@
   <libro>
     <titulo>Crónica de una Muerte Anunciada</titulo>
     <autor>Gabriel García Márquez</autor>
-    <ani<libros>
-  <libro>
-    <titulo>El Quijote</titulo>
-    <autor>Miguel de Cervantes</autor>
-    <anio>1605</anio>
-  </libro>
-  <libro>
-    <titulo>Cien Años de Soledad</titulo>
-    <autor>Gabriel García Márquez</autor>
-    <anio>1967</anio>
-  </libro>
-  <libro>
-    <titulo>La Sombra del Viento</titulo>
-    <autor>Carlos Ruiz Zafón</autor>
-    <anio>2001</anio>
-  </libro>
-  <libro>
-    <titulo>1984</titulo>
-    <autor>George Orwell</autor>
-    <anio>1949</anio>
-  </libro>
-  <libro>
-    <titulo>Crónica de una Muerte Anunciada</titulo>
-    <autor>Gabriel García Márquez</autor>
     <anio>1981</anio>
   </libro>
-</libros>
-o>1981</anio>
+  <libro>
+    <titulo>La Ciudad de las Bestias</titulo>
+    <autor>Isabel Allende</autor>
+    <anio>2002</anio>
+  </libro>
+  <libro>
+    <titulo>Crimen y Castigo</titulo>
+    <autor>Fiódor Dostoyevski</autor>
+    <anio>1866</anio>
+  </libro>
+  <libro>
+    <titulo>Hábitos Atómicos</titulo>
+    <autor>James Clear</autor>
+    <anio>2018</anio>
+  </libro>
+  <libro>
+    <titulo>Paula</titulo>
+    <autor>Isabel Allende</autor>
+    <anio>1994</anio>
+  </libro>
+  <libro>
+    <titulo>La Vegetariana</titulo>
+    <autor>Han Kang</autor>
+    <anio>2007</anio>
+  </libro>
+  <libro>
+    <titulo>Actos Humanos</titulo>
+    <autor>Han Kang</autor>
+    <anio>2014</anio>
   </libro>
 </libros>


### PR DESCRIPTION
Se creo e implementó el método mostrar() en el XmlController para leer el archivo XML, convertir los datos a JSON y enviarlos a la vista preferencias.blade.php.